### PR TITLE
#156045741 Fix issue with docker custom machine image builder

### DIFF
--- a/Dockerfiles/bakery.Dockerfile
+++ b/Dockerfiles/bakery.Dockerfile
@@ -1,0 +1,45 @@
+FROM golang:alpine
+
+# #update the image 
+# RUN apk update \ 
+#     &&   apk add ca-certificates wget zip unzip sudo bash \
+#     &&   update-ca-certificates 
+
+# #install ansible 
+# RUN apk add ansible
+
+# # Download packer
+
+# RUN wget https://releases.hashicorp.com/packer/1.2.1/packer_1.2.1_linux_amd64.zip
+# RUN unzip packer_1.2.1_linux_amd64.zip -d packer
+# RUN packer
+# RUN sudo mv packer /usr/bin/packer
+
+# #Download terraform
+# RUN wget https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_linux_amd64.zip
+# RUN unzip terraform_0.11.3_linux_amd64.zip -d terraform
+# RUN sudo mv terraform /usr/local/bin/
+
+# RUN sudo packer
+
+ENV TERRAFORM_VERSION=0.10.0
+
+RUN apk add --update git bash openssh
+
+ENV TF_DEV=true
+ENV TF_RELEASE=true
+
+# Clone and build terraform
+WORKDIR $GOPATH/src/github.com/hashicorp/terraform
+RUN git clone https://github.com/hashicorp/terraform.git ./ && \
+    git checkout v${TERRAFORM_VERSION} && \
+    /bin/bash scripts/build.sh
+
+#clone and build packer
+RUN go get github.com/mitchellh/gox
+RUN go get github.com/hashicorp/packer
+WORKDIR $GOPATH/src/github.com/hashicorp/packer
+
+RUN go build -o bin/packer .
+
+RUN apk add ansible

--- a/Dockerfiles/bakery.Dockerfile
+++ b/Dockerfiles/bakery.Dockerfile
@@ -1,28 +1,6 @@
 FROM golang:alpine
 
-# #update the image 
-# RUN apk update \ 
-#     &&   apk add ca-certificates wget zip unzip sudo bash \
-#     &&   update-ca-certificates 
-
-# #install ansible 
-# RUN apk add ansible
-
-# # Download packer
-
-# RUN wget https://releases.hashicorp.com/packer/1.2.1/packer_1.2.1_linux_amd64.zip
-# RUN unzip packer_1.2.1_linux_amd64.zip -d packer
-# RUN packer
-# RUN sudo mv packer /usr/bin/packer
-
-# #Download terraform
-# RUN wget https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_linux_amd64.zip
-# RUN unzip terraform_0.11.3_linux_amd64.zip -d terraform
-# RUN sudo mv terraform /usr/local/bin/
-
-# RUN sudo packer
-
-ENV TERRAFORM_VERSION=0.10.0
+ENV TERRAFORM_VERSION=0.11.3
 
 RUN apk add --update git bash openssh
 
@@ -39,10 +17,15 @@ RUN git clone https://github.com/hashicorp/terraform.git ./ && \
 RUN go get github.com/mitchellh/gox
 RUN go get github.com/hashicorp/packer
 WORKDIR $GOPATH/src/github.com/hashicorp/packer
-
 RUN go build -o bin/packer .
 
-RUN apk add py-pip
-RUN apk add gcc git libffi-dev musl-dev openssl-dev perl py-pip python python-dev sshpass
-RUN apk add make
+# install ansible and dependencies
+RUN apk update
+RUN apk add sudo make gcc git libffi-dev musl-dev openssl-dev perl py-pip python python-dev sshpass
 RUN pip install ansible
+RUN ansible --version
+
+RUN adduser -S baker -s /bin/bash -h /home/baker
+USER baker
+RUN mkdir ~/.ssh
+WORKDIR /home/baker


### PR DESCRIPTION
#### What does this PR do?
Fixes issues when trying to run packer build from inside a docker image.

#### Description of Task to be completed?
While trying to build a machine image with packer and ansible, ansible fails because of permission errors on the remote machine.

#### How should this be manually tested?
Pull the docker image from and navigate to any directory inside the Packer directory the run packer build packer.json. It should successfully run the packer build.

#### What are the relevant pivotal tracker stories?

[156045741](https://www.pivotaltracker.com/story/show/156045741)
#### Any background context you want to add?
Docker has to be run as a user without root privileges for ansible to run successfully.
